### PR TITLE
feat: a skiplist implementation for MemTable

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -130,7 +130,7 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PenaltyIndentedWhitespace: 0
-PointerAlignment: Left
+PointerAlignment: Right
 PPIndentWidth:   -1
 RawStringFormats:
   - Language:        Cpp

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -1,7 +1,6 @@
 #include <optional>
 
-#include <fmt/format.h>
-#include <fmt/os.h>
+#include <fmt/core.h>
 #include <gtest/gtest.h>
 #include <tl/expected.hpp>
 

--- a/include/skiplist.hpp
+++ b/include/skiplist.hpp
@@ -1,12 +1,35 @@
 #include <optional>
 #include <string>
+#include <vector>
 
 using Key = std::string;
 using Value = std::string;
 
+struct Node {
+  Key key;
+  Value value;
+
+  std::vector<Node*> forward;
+  Node(const Key& k, const Value& v, int level) noexcept
+    : key(k), value(v), forward(std::vector<Node*>(level + 1, nullptr)) {}
+};
+
+/// Skiplist is not thread-safe yet
 class Skiplist {
+  /// A dummy node before the 1st  node. It's always the tallest node;
+  Node* head;
+  int level;
+  size_t __size;
+
+  Node* find(const Key& key) const noexcept;
+  std::optional<Value> pop(const Key& key) noexcept;
+
  public:
+  Skiplist() noexcept;
+
+  size_t size() const noexcept { return __size; }
+
   void put(const Key& key, const Value& value) noexcept;
   std::optional<Value> get(const Key& key) const noexcept;
-  void del(const Key& key) noexcept;
+  bool del(const Key& key) noexcept;
 };

--- a/src/skiplist.cpp
+++ b/src/skiplist.cpp
@@ -1,12 +1,103 @@
+#include <cstdlib>
+#include <stack>
+
+#include <stdlib.h>
+
+#include "common.hpp"
 #include "skiplist.hpp"
 
-void Skiplist::put(const Key& key, const Value& value) noexcept {
-  /* TODO:  <18-08-22, Congee> */
+static unsigned int seed = 42;
+
+int rand_level() {
+  int level;
+  for (level = 0; rand_r(&seed) & 1; level++)
+    ;
+  return level;
 }
 
-std::optional<Value> Skiplist::get(const Key& key) const noexcept {
-  /* TODO:  <18-08-22, Congee> */
-  return {};
+/// This Skiplist implementation is not thread-safe. Range query and random
+/// access will be available in the future. Duplicates are not allowed.
+///
+/// References:
+/// https://opendsa-server.cs.vt.edu/OpenDSA/Books/CS3/html/SkipList.html
+Skiplist::Skiplist() noexcept
+  : head(new Node("", "", 0)), level(-1), __size(0) {
+  std::srand(seed);
 }
 
-void Skiplist::del(const Key& key) noexcept { /* TODO:  <18-08-22, Congee> */ }
+/// find the previous node
+Node *Skiplist::find(const Key &key) const noexcept {
+  auto curr = head;
+  for (int i = level; i >= 0; --i) {
+    while (curr->forward[i] && curr->forward[i]->key < key)
+      curr = curr->forward[i];
+  }
+
+  return curr;
+}
+
+std::optional<Value> Skiplist::get(const Key &key) const noexcept {
+  auto it = find(key);
+  // 3 5 8 -> null
+  // 1 -> 3
+  // 4 -> 3
+  // 8 -> 8
+  // 9 -> null
+  auto x = it->forward[0];
+  return (x && x->key == key) ? Some(x->value) : None;
+}
+
+void Skiplist::put(const Key &key, const Value &value) noexcept {
+  int new_level = rand_level();
+  if (level < new_level) {
+    while (head->forward.size() < (size_t)new_level + 1)
+      head->forward.push_back(nullptr);
+    level = new_level;
+  }
+
+  std::vector<Node *> vec(level + 1);
+  auto curr = head;
+  for (int i = level; i >= 0; --i) {
+    // existing
+    if (curr->forward[i] && curr->forward[i]->key == key) {
+      curr->forward[i]->value = value;
+      return;
+    };
+
+    while (curr->forward[i] && curr->forward[i]->key < key)
+      curr = curr->forward[i];
+    vec[i] = curr;
+  }
+
+  auto node = new Node(key, value, new_level);
+  for (int i = 0; i <= new_level; ++i) {
+    node->forward[i] = vec[i]->forward[i];
+    vec[i]->forward[i] = node;
+  }
+
+  __size++;
+}
+
+std::optional<Value> Skiplist::pop(const Key &key) noexcept {
+  std::vector<Node *> vec(level + 1);  // actually unnecessary
+  auto curr = head;
+  for (int i = level; i >= 0; --i) {
+    while (curr->forward[i] && curr->forward[i]->key < key)
+      curr = curr->forward[i];
+    vec[i] = curr;
+  }
+
+  auto to_delete = curr->forward[0];
+  if (to_delete == nullptr || to_delete->key != key) return None;
+
+  for (size_t i = 0; i < to_delete->forward.size(); ++i) {
+    vec[i]->forward[i] = to_delete->forward[i];
+  }
+
+  auto value = to_delete->value;
+  delete to_delete;
+  __size--;
+  return value;
+}
+
+bool Skiplist::del(const Key &key) noexcept { return pop(key).has_value(); }

--- a/tests/test_skiplist.cpp
+++ b/tests/test_skiplist.cpp
@@ -2,8 +2,31 @@
 
 #include "skiplist.hpp"
 
+TEST(Skiplist, skiplist_get_from_empty) {
+  Skiplist sl;
+  EXPECT_FALSE(sl.get("foo").has_value());
+}
+
 TEST(Skiplist, skiplist) {
   Skiplist sl;
-  sl.put("foo", "bar");
-  EXPECT_FALSE(sl.get("foo").has_value());
+  EXPECT_FALSE(sl.get("nonexistent").has_value());
+
+  sl.put("foo", "foo");
+  sl.put("bar", "bar");
+  sl.put("qux", "qux");
+
+  EXPECT_EQ(sl.get("foo").value(), "foo");
+  EXPECT_FALSE(sl.get("nonexistent").has_value());
+
+  sl.put("foo", "foo0");
+  EXPECT_EQ(sl.get("foo").value(), "foo0");
+
+  // clang-format off
+  sl.del("foo"); EXPECT_EQ(sl.size(), 2);
+  sl.del("bar"); EXPECT_EQ(sl.size(), 1);
+  sl.del("qux"); EXPECT_EQ(sl.size(), 0);
+  // clang-format on
+
+  EXPECT_FALSE(sl.del("foo"));
+  EXPECT_EQ(sl.size(), 0);
 }


### PR DESCRIPTION
- fix: make custom fmt::println constexpr for libstdc++
- feat(build): enable Codecov in GitHub CI
- feat: a skiplist implementation for MemTable

This MemTable was designed as a middleware between our KV interface and the
underlying storage SSTable
